### PR TITLE
KH-7450 Require Intercom plugin version 8

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -35,7 +35,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         </config-file>
 
         <dependency id="cordova-support-google-services" version="^1.3.0"/>
-        <dependency id="cordova-plugin-intercom" version="^7.1.0"/>
+        <dependency id="cordova-plugin-intercom" version="^8.0.0"/>
         <dependency id="urbanairship-cordova" version="^7.6.0"/>
 
         <framework src="com.google.firebase:firebase-core:$FIREBASE_CORE_VERSION" />


### PR DESCRIPTION
This plugin has a dependency on Intercom.  So to update Intercom we need to start here.  We'll do the same maneuver for UrbanAirship.